### PR TITLE
Fix v3/v4 uid encoding

### DIFF
--- a/lib/ex_uid2/encryption/identity.ex
+++ b/lib/ex_uid2/encryption/identity.ex
@@ -76,7 +76,7 @@ defmodule ExUid2.Encryption.Identity do
      %__MODULE__{
        version: 3,
        site_id: site_id,
-       id_bin: id_bin,
+       id_bin: id_bin |> :base64.encode(),
        established_ms: established_ms
      }}
   end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -46,6 +46,18 @@ defmodule Test.Support.Utils do
     }
 
     opts = Map.merge(default_token_opts, opts)
+
+    opts =
+      case opts[:version] do
+        2 ->
+          opts
+
+        _ ->
+          uid = opts[:uid]
+          decoded_uid = :base64.decode(uid)
+          Map.put(opts, :uid, decoded_uid)
+      end
+
     uid2 = ExUid2.Uid2.new(opts)
 
     {:ok, token} =


### PR DESCRIPTION
Problem:
The uid in v3/v4 tokens is not base64 encoded before being encrypted, but it is expected to be encoded at the decryption time.

Solution:
Base64 encode the uid for v3/v4 token at decryption time.