### PR TITLE
Change keyring endpoint from sharing to bidstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ and misconceptions, so this specification is likely to be erroneous or incomplet
 shown to work for decoding encrypted UID2 tokens in a production environment.
 
 ### General flow
-1. A keyring is periocically updated by querying the `/v2/key/sharing` endpoint.
+1. A keyring is periocically updated by querying the `/v2/key/bidstream` endpoint.
 2. The encrypted token envelope is fetched from the bid request.
 3. The token is base64 decoded.
 4. The envelope is parsed to extract the token version and other info necessary for decryption.
@@ -78,8 +78,8 @@ shown to work for decoding encrypted UID2 tokens in a production environment.
 9. The site key ID parsed from the master payload is used to get the site key from the keyring.
 10. The indentity payload is decrypted.
 
-### `/v2/key/sharing` request
-While the `/v2/key/sharing` endpoint is undocumented, The workflow to query UID2's endpoints is documented, the 
+### `/v2/key/bidstream` request
+While the `/v2/key/bidstream` endpoint is undocumented, The workflow to query UID2's endpoints is documented, the 
 [Encrypting Requests and Decrypting Responses](https://unifiedid.com/docs/getting-started/gs-encryption-decryption#encryption-and-decryption-code-examples) documentation seem to apply there. It is what 
 this library is doing.
 

--- a/lib/ex_uid2/api/bidstream.ex
+++ b/lib/ex_uid2/api/bidstream.ex
@@ -1,18 +1,18 @@
-defmodule ExUid2.Api.Sharing do
+defmodule ExUid2.Api.Bidstream do
   @moduledoc """
-  This module provides the interface for the DSP to access the UID2 Operator Services's key sharing endpoint.
+  This module provides the interface for the DSP to access the UID2 Operator Services's key bidstream endpoint.
   """
   alias ExUid2.Api
   alias ExUid2.Keyring
 
-  @key_sharing_path "/v2/key/sharing"
+  @bidstream_path "/v2/key/bidstream"
 
   @doc """
   Request the decryption keys necessary to decrypt UID2 tokens.
   """
   @spec fetch_keyring() :: {:ok, Keyring.t()} | {:error, any()}
   def fetch_keyring() do
-    case Api.post_encrypted_request(@key_sharing_path, "") do
+    case Api.post_encrypted_request(@bidstream_path, "") do
       {:ok, %{"status" => "success", "body" => body}} ->
         {:ok, Keyring.new(body)}
 

--- a/lib/ex_uid2/dsp.ex
+++ b/lib/ex_uid2/dsp.ex
@@ -148,7 +148,7 @@ defmodule ExUid2.Dsp do
   end
 
   defp refresh_keyring() do
-    case Api.Sharing.fetch_keyring() do
+    case Api.Bidstream.fetch_keyring() do
       {:ok, fresh_keyring} ->
         :ets.insert(@table_name, {@keyring, fresh_keyring})
         :ok

--- a/lib/ex_uid2/keyring.ex
+++ b/lib/ex_uid2/keyring.ex
@@ -8,7 +8,7 @@ defmodule ExUid2.Keyring do
 
   * `:keys` - The list of available keys
 
-  * `:info` - Other information provided via the UID2 operator server's `/v2/keys/sharing` endpoint
+  * `:info` - Other information provided via the UID2 operator server's `/v2/keys/bidstream` endpoint
   """
   @type t :: %__MODULE__{
           keys: %{non_neg_integer() => __MODULE__.Key.t()},
@@ -72,7 +72,9 @@ defmodule ExUid2.Keyring do
   end
 
   defmodule Info do
-    @moduledoc false
+    @moduledoc """
+    Struct holding information about the keyring.
+    """
     @type t :: %__MODULE__{}
     defstruct [
       :identity_scope,

--- a/test/api/bidstream_test.exs
+++ b/test/api/bidstream_test.exs
@@ -1,7 +1,7 @@
-defmodule Test.Api.SharingTest do
+defmodule Test.Api.BidstreamTest do
   use ExUnit.Case, async: true
 
-  alias ExUid2.Api.Sharing
+  alias ExUid2.Api.Bidstream
   alias Test.Support.Utils
 
   test "fetch_keyring/0 sends the encrypted request, decrypts the response and parses the keyring " do
@@ -10,7 +10,7 @@ defmodule Test.Api.SharingTest do
     keyring_text = Utils.keyring_json(keyring_opts)
     Utils.prepare_response(keyring_text)
 
-    {:ok, keyring} = Sharing.fetch_keyring()
+    {:ok, keyring} = Bidstream.fetch_keyring()
 
     expected_keyring = Utils.keyring(keyring_opts)
     assert match?(^expected_keyring, keyring)
@@ -18,7 +18,7 @@ defmodule Test.Api.SharingTest do
 
   test "fetch_keyring/0 returns an error if the request fails" do
     Req.Test.expect(ExUid2.Dsp, &Plug.Conn.send_resp(&1, 500, "internal server error"))
-    response = Sharing.fetch_keyring()
+    response = Bidstream.fetch_keyring()
     assert match?({:error, %Req.Response{status: 500}}, response)
   end
 
@@ -26,7 +26,7 @@ defmodule Test.Api.SharingTest do
     invalid_text = ~S'{"wrong":"format"}'
     Utils.prepare_response(invalid_text)
 
-    response = Sharing.fetch_keyring()
+    response = Bidstream.fetch_keyring()
     assert match?({:error, {:unexpected_response, _}}, response)
   end
 end


### PR DESCRIPTION
This PR changes the endpoint used to fetch the keyring from `v2/key/sharing` to `/v2/key/bidstream`.