### PR TITLE
Handle error when the encrypted master payload can't be parsed

### DIFF
--- a/lib/ex_uid2/encryption/master_payload.ex
+++ b/lib/ex_uid2/encryption/master_payload.ex
@@ -39,15 +39,27 @@ defmodule ExUid2.Encryption.MasterPayload do
     payload_size = byte_size(payload)
     encrypted_data_size = payload_size - (@nonce_size + @tag_size)
 
-    <<nonce::binary-size(@nonce_size), data::binary-size(encrypted_data_size),
-      tag::binary-size(@tag_size)>> = payload
+    with {:parse_payload,
+          <<nonce::binary-size(@nonce_size), data::binary-size(encrypted_data_size),
+            tag::binary-size(@tag_size)>>} <- {:parse_payload, payload},
+         {:decrypt, {:ok, decrypted_bin}} <- {:decrypt, decrypt(key, nonce, data, tag)} do
+      parse_v3(decrypted_bin)
+    else
+      {:parse_payload, _} ->
+        {:error, :cannot_parse_encrypted_payload}
 
+      {:decrypt, error} ->
+        error
+    end
+  end
+
+  defp decrypt(key, nonce, data, tag) do
     case :crypto.crypto_one_time_aead(:aes_256_gcm, key.secret, nonce, data, <<>>, tag, false) do
       :error ->
         {:error, :cannot_decrypt_payload}
 
       decrypted_bin ->
-        parse_v3(decrypted_bin)
+        {:ok, decrypted_bin}
     end
   end
 

--- a/test/master_payload_test.exs
+++ b/test/master_payload_test.exs
@@ -1,0 +1,17 @@
+defmodule Test.Encryption.MasterPayload do
+  use ExUnit.Case
+
+  alias ExUid2.Encryption.MasterPayload
+  alias ExUid2.Encryption.EncryptedToken
+
+  test "Invalid V3 Tokens return an error when they can't be parsed" do
+    key = "fake_key"
+
+    master_payload =
+      "invalid" |> Base.encode64()
+
+    token = %EncryptedToken{version: 3, master_payload: master_payload}
+
+    {:error, :cannot_parse_encrypted_payload} = MasterPayload.decrypt(token, key)
+  end
+end


### PR DESCRIPTION
Problem:
When the encrypted master payload doesn't match the specification, `MasterPayload.decrypt/2` fails the binary pattern matching attempt and raises an exception.

Solution:
Gracefully handle the badmatch case and return an informative error instead.